### PR TITLE
Expand Command return type with an error case

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,23 @@ gleam add outil
 ```
 
 and its documentation can be found at <https://hexdocs.pm/outil>.
+
+## Changelog
+
+### 0.3.0
+
+* Expanded the return type of commands to include a way for the command code itself to return errors.
+* **BREAKING** Some types were renamed to support the above, and be more clear.
+
+### 0.2.1
+
+* Fixed some docs.
+
+### 0.2.0
+
+* **BREAKING** Simplified command implementation. The function is the command now, it no longer returns a `Command` value.
+
+### 0.1.0
+
+* Hello world!
+* Something kind of working.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "outil"
-version = "0.2.1"
+version = "0.3.0"
 description = "A Gleam library for writing command line tools."
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "fabjan", repo = "outil" }

--- a/src/outil.gleam
+++ b/src/outil.gleam
@@ -47,18 +47,22 @@ pub type OptValue {
 }
 
 /// Non-normal return values from executing a command.
-pub type Return {
+pub type CommandReturn(a) {
+  /// An error in parsing the command line.
   CommandLineError(reason: Reason, usage: String)
+  /// An error in executing the command, `a` is your error value.
+  CommandError(a)
+  /// The user asked for help.
   Help(usage: String)
 }
 
-/// A function from the argument vector (in the given command) to a result.
-pub type ArgvFunction(a) =
-  fn(Command) -> Result(a, Return)
+/// The result of executing a command.
+pub type CommandResult(a, b) =
+  Result(a, CommandReturn(b))
 
 /// The type of continuation functions in building a command.
-pub type WithArgument(a, b) =
-  fn(ArgvFunction(a), Command) -> b
+pub type Configure(a, b, c) =
+  fn(fn(Command) -> CommandResult(a, c), Command) -> b
 
 /// Parse a Bool from a string.
 pub fn parse_bool(arg: String) -> Result(Bool, Nil) {

--- a/src/outil/arg.gleam
+++ b/src/outil/arg.gleam
@@ -3,30 +3,30 @@ import gleam/int
 import gleam/list
 import gleam/result
 import outil.{
-  Argument, BoolArgument, Command, FloatArgument, IntArgument, StringArgument,
-  WithArgument, parse_bool,
+  Argument, BoolArgument, Command, Configure, FloatArgument, IntArgument,
+  StringArgument, parse_bool,
 }
 import outil/error.{MalformedArgument,
   MissingArgument, OutOfPlaceOption, Reason}
 import outil/help.{handle_error}
 
 /// Add a positional bool argument to the command before continuing.
-pub fn bool(cmd: Command, name: String, continue: WithArgument(Bool, a)) -> a {
+pub fn bool(cmd: Command, name: String, continue: Configure(Bool, a, _)) -> a {
   with_positional_argument(cmd, BoolArgument(name), parse_bool, continue)
 }
 
 /// Add a positional float argument to the command before continuing.
-pub fn float(cmd: Command, name: String, continue: WithArgument(Float, a)) -> a {
+pub fn float(cmd: Command, name: String, continue: Configure(Float, a, _)) -> a {
   with_positional_argument(cmd, FloatArgument(name), float.parse, continue)
 }
 
 /// Add a positional int argument to the command before continuing.
-pub fn int(cmd: Command, name: String, continue: WithArgument(Int, a)) -> a {
+pub fn int(cmd: Command, name: String, continue: Configure(Int, a, _)) -> a {
   with_positional_argument(cmd, IntArgument(name), int.parse, continue)
 }
 
 /// Add a positional string argument to the command before continuing.
-pub fn string(cmd: Command, name: String, cont: WithArgument(String, a)) -> a {
+pub fn string(cmd: Command, name: String, cont: Configure(String, a, _)) -> a {
   with_positional_argument(cmd, StringArgument(name), Ok, cont)
 }
 
@@ -38,7 +38,7 @@ fn with_positional_argument(
   cmd: Command,
   argument: Argument,
   parse: fn(String) -> Result(b, Nil),
-  continue: WithArgument(b, a),
+  continue: Configure(b, a, _),
 ) -> a {
   let arg_pos = list.length(cmd.arguments)
   let arg_parser = positional_arg_parser(arg_pos, argument.name, parse)

--- a/src/outil/help.gleam
+++ b/src/outil/help.gleam
@@ -4,14 +4,14 @@ import gleam/list
 import gleam/option
 import gleam/string
 import outil.{
-  BoolOpt, Command, CommandLineError, FloatOpt, Help, IntOpt, Opt, OptValue,
-  Return, StringOpt,
+  BoolOpt, Command, CommandLineError, CommandReturn, FloatOpt, Help, IntOpt, Opt,
+  OptValue, StringOpt,
 }
 import outil/error.{Reason}
 
 /// Transform parse errors into a return value, this is where we
 /// check for the help flag.
-pub fn handle_error(reason: Reason, cmd: Command) -> Return {
+pub fn handle_error(reason: Reason, cmd: Command) -> CommandReturn(a) {
   // This solution (piggybacking on the error handling) is not ideal since it
   // means we can only show help for commands that try to parse any arguments
   // or options. But if your command doesn't take any arguments or options

--- a/src/outil/opt.gleam
+++ b/src/outil/opt.gleam
@@ -5,7 +5,7 @@ import gleam/option.{None, Option, Some}
 import gleam/result
 import gleam/string
 import outil.{
-  BoolOpt, Command, FloatOpt, IntOpt, Opt, StringOpt, WithArgument, parse_bool,
+  BoolOpt, Command, Configure, FloatOpt, IntOpt, Opt, StringOpt, parse_bool,
 }
 import outil/error.{MalformedArgument, MissingArgument, Reason}
 import outil/help.{handle_error}
@@ -15,7 +15,7 @@ pub fn bool(
   cmd: Command,
   long: String,
   description: String,
-  continue: WithArgument(Bool, a),
+  continue: Configure(Bool, a, _),
 ) -> a {
   bool_(cmd, long, None, description, continue)
 }
@@ -26,7 +26,7 @@ pub fn bool_(
   long: String,
   short: Option(String),
   description: String,
-  continue: WithArgument(Bool, a),
+  continue: Configure(Bool, a, _),
 ) -> a {
   let opt = Opt(long, short, description, BoolOpt)
   let opt_parser = fn(run_cmd: Command) {
@@ -43,7 +43,7 @@ pub fn float(
   long: String,
   description: String,
   default: Float,
-  continue: WithArgument(Float, a),
+  continue: Configure(Float, a, _),
 ) -> a {
   float_(cmd, long, None, description, default, continue)
 }
@@ -55,7 +55,7 @@ pub fn float_(
   short: Option(String),
   description: String,
   default: Float,
-  continue: WithArgument(Float, a),
+  continue: Configure(Float, a, _),
 ) -> a {
   let opt = Opt(long, short, description, FloatOpt(default))
 
@@ -68,7 +68,7 @@ pub fn int(
   long: String,
   description: String,
   default: Int,
-  continue: WithArgument(Int, a),
+  continue: Configure(Int, a, _),
 ) -> a {
   int_(cmd, long, None, description, default, continue)
 }
@@ -80,7 +80,7 @@ pub fn int_(
   short: Option(String),
   description: String,
   default: Int,
-  continue: WithArgument(Int, a),
+  continue: Configure(Int, a, _),
 ) -> a {
   let opt = Opt(long, short, description, IntOpt(default))
 
@@ -93,7 +93,7 @@ pub fn string(
   long: String,
   description: String,
   default: String,
-  continue: WithArgument(String, a),
+  continue: Configure(String, a, _),
 ) -> a {
   string_(cmd, long, None, description, default, continue)
 }
@@ -105,7 +105,7 @@ pub fn string_(
   short: Option(String),
   description: String,
   default: String,
-  continue: WithArgument(String, a),
+  continue: Configure(String, a, _),
 ) -> a {
   let opt = Opt(long, short, description, StringOpt(default))
 
@@ -121,7 +121,7 @@ pub fn with_named_option(
   opt: Opt,
   default: b,
   parse: fn(String) -> Result(b, Nil),
-  continue: WithArgument(b, a),
+  continue: Configure(b, a, _),
 ) -> a {
   let opt_parser = named_opt_parser(opt.long, opt.short, parse, default)
   let opt_parser = fn(run_cmd: Command) {


### PR DESCRIPTION
Problem
--------

The current solution forces command implementations to be fault free. It would be nice if users can return errors.

Solution
--------

Expand the return type to include a generic error case `CommandError(a)` for user code to return it it needs to.

Fixes #7
