### PR TITLE
Add convenience helpers for command errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ import gleam/io
 import gleam/list
 import gleam/result
 import gleam/string
-import outil.{command}
+import outil.{command, print_usage_and_exit}
 import outil/arg
 import outil/opt
 
@@ -29,21 +29,14 @@ fn say_hello(args) {
 }
 
 pub fn main() {
-  // Erlang is not required, this example just uses it for getting ARGV
   let args =
+    // Erlang is not required, this example just uses it for getting ARGV
     erlang.start_arguments()
+    // drop the program name from the arguments we pass in
     |> list.drop(1)
 
-  // drop the program name from the arguments we pass in
   say_hello(args)
-  |> result.map_error(print_usage)
-}
-
-fn print_usage(ret) {
-  case ret {
-    outil.CommandLineError(_, usage) -> io.println(usage)
-    outil.Help(usage) -> io.println(usage)
-  }
+  |> result.map_error(print_usage_and_exit)
 }
 ```
 
@@ -74,6 +67,10 @@ gleam add outil
 and its documentation can be found at <https://hexdocs.pm/outil>.
 
 ## Changelog
+
+### 0.3.1
+
+* Added convenience helpers print_usage and print_usage_and_exit for handling command errors.
 
 ### 0.3.0
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "outil"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Gleam library for writing command line tools."
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "fabjan", repo = "outil" }

--- a/src/outil_ffi.mjs
+++ b/src/outil_ffi.mjs
@@ -1,0 +1,7 @@
+export function exit(code) {
+  if (globalThis.Deno) {
+    return Deno.exit(code);
+  } else {
+    return process.exit(code);
+  }
+}


### PR DESCRIPTION
This should save some boiler plate for many simple programs that just want to print usage and exit if the user made an error.

* print_usage
* print_usage_and_exit

Resolves #8