### PR TITLE
Fix help for opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,8 @@ fn say_hello(args) {
 }
 
 pub fn main() {
-  let args =
-    // Erlang is not required, this example just uses it for getting ARGV
-    erlang.start_arguments()
-    // drop the program name from the arguments we pass in
-    |> list.drop(1)
+  // Erlang is not required, this example just uses it for getting ARGV
+  let args = erlang.start_arguments()
 
   say_hello(args)
   |> result.map_error(print_usage_and_exit)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ and its documentation can be found at <https://hexdocs.pm/outil>.
 
 ## Changelog
 
+### 0.3.2
+
+* Fixed a bug where the automatic `--help` flag didn't react unless the command had positional arguments.
+
 ### 0.3.1
 
 * Added convenience helpers print_usage and print_usage_and_exit for handling command errors.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "outil"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Gleam library for writing command line tools."
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "fabjan", repo = "outil" }

--- a/src/outil.gleam
+++ b/src/outil.gleam
@@ -90,9 +90,13 @@ pub type CommandReturn(a) {
 pub type CommandResult(a, b) =
   Result(a, CommandReturn(b))
 
+/// The type of functions that execute a command.
+pub type RunCommand(a, b) =
+  fn(Command) -> CommandResult(a, b)
+
 /// The type of continuation functions in building a command.
 pub type Configure(a, b, c) =
-  fn(fn(Command) -> CommandResult(a, c), Command) -> b
+  fn(RunCommand(a, c), Command) -> b
 
 /// Parse a Bool from a string.
 pub fn parse_bool(arg: String) -> Result(Bool, Nil) {

--- a/src/outil/arg.gleam
+++ b/src/outil/arg.gleam
@@ -8,7 +8,7 @@ import outil.{
 }
 import outil/error.{MalformedArgument,
   MissingArgument, OutOfPlaceOption, Reason}
-import outil/help.{handle_error}
+import outil/help
 
 /// Add a positional bool argument to the command before continuing.
 pub fn bool(cmd: Command, name: String, continue: Configure(Bool, a, _)) -> a {
@@ -42,10 +42,7 @@ fn with_positional_argument(
 ) -> a {
   let arg_pos = list.length(cmd.arguments)
   let arg_parser = positional_arg_parser(arg_pos, argument.name, parse)
-  let arg_parser = fn(run_cmd: Command) {
-    arg_parser(run_cmd.argv)
-    |> result.map_error(fn(reason) { handle_error(reason, run_cmd) })
-  }
+  let arg_parser = fn(run_cmd: Command) { help.wrap_usage(run_cmd, arg_parser) }
 
   continue(arg_parser, append_argument(cmd, argument))
 }

--- a/src/outil/opt.gleam
+++ b/src/outil/opt.gleam
@@ -8,7 +8,7 @@ import outil.{
   BoolOpt, Command, Configure, FloatOpt, IntOpt, Opt, StringOpt, parse_bool,
 }
 import outil/error.{MalformedArgument, MissingArgument, Reason}
-import outil/help.{handle_error}
+import outil/help
 
 /// Add a named bool option to the command before continuing.
 pub fn bool(
@@ -29,10 +29,8 @@ pub fn bool_(
   continue: Configure(Bool, a, _),
 ) -> a {
   let opt = Opt(long, short, description, BoolOpt)
-  let opt_parser = fn(run_cmd: Command) {
-    bool_opt_parser(long, short)(run_cmd.argv)
-    |> result.map_error(fn(reason) { handle_error(reason, run_cmd) })
-  }
+  let opt_parser = bool_opt_parser(long, short)
+  let opt_parser = fn(run_cmd: Command) { help.wrap_usage(run_cmd, opt_parser) }
 
   continue(opt_parser, add_option(cmd, opt))
 }
@@ -124,10 +122,7 @@ pub fn with_named_option(
   continue: Configure(b, a, _),
 ) -> a {
   let opt_parser = named_opt_parser(opt.long, opt.short, parse, default)
-  let opt_parser = fn(run_cmd: Command) {
-    opt_parser(run_cmd.argv)
-    |> result.map_error(fn(reason) { handle_error(reason, run_cmd) })
-  }
+  let opt_parser = fn(run_cmd: Command) { help.wrap_usage(run_cmd, opt_parser) }
 
   continue(opt_parser, add_option(cmd, opt))
 }

--- a/test/outil_test.gleam
+++ b/test/outil_test.gleam
@@ -94,6 +94,27 @@ fn twoface_cmd(args: List(String)) -> CommandResult(String, String) {
   }
 }
 
+const help_usage = "help -- Test help text.
+
+Usage: help
+
+Options:
+  --foo  bar (string, default: \"baz\")"
+
+fn help_cmd(args: List(String)) -> CommandResult(String, Nil) {
+  use cmd <- command("help", "Test help text.", args)
+  use foo, cmd <- opt.string(cmd, "foo", "bar", "baz")
+
+  foo(cmd)
+}
+
+pub fn help_usage_test() {
+  assert Error(Help(usage)) = help_cmd(["--help"])
+
+  usage
+  |> should.equal(help_usage)
+}
+
 pub fn command_usage_test() {
   let result = hello_cmd([])
 

--- a/test/outil_test.gleam
+++ b/test/outil_test.gleam
@@ -1,3 +1,4 @@
+import gleam/option.{Some}
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -65,6 +66,10 @@ fn the_whole_fruit_basket_cmd(
   use corge, cmd <- opt.float(cmd, "corge", "how much corge?", 1.0)
   use grault, cmd <- opt.int(cmd, "grault", "how many grault?", 1)
   use garply, cmd <- opt.string(cmd, "garply", "which garply?", "default")
+  use waldo, cmd <- opt.bool_(cmd, "waldo", Some("w"), "invert quux?")
+  use fred, cmd <- opt.float_(cmd, "fred", Some("f"), "multiply corge", 10.0)
+  use plugh, cmd <- opt.int_(cmd, "plugh", Some("p"), "add to grault", 1)
+  use xyzzy, cmd <- opt.string_(cmd, "xyzzy", Some("x"), "garply suffix", "!")
 
   try foo = foo(cmd)
   try bar = bar(cmd)
@@ -76,7 +81,21 @@ fn the_whole_fruit_basket_cmd(
   try grault = grault(cmd)
   try garply = garply(cmd)
 
-  Ok(FruitBasket(foo, bar, baz, qux, quux, corge, grault, garply))
+  try waldo = waldo(cmd)
+  try fred = fred(cmd)
+  try plugh = plugh(cmd)
+  try xyzzy = xyzzy(cmd)
+
+  Ok(FruitBasket(
+    foo,
+    bar,
+    baz,
+    qux,
+    quux && !waldo,
+    corge *. fred,
+    grault + plugh,
+    garply <> xyzzy,
+  ))
 }
 
 fn twoface_cmd(args: List(String)) -> CommandResult(String, String) {
@@ -183,12 +202,12 @@ pub fn malformed_argument_test() {
 pub fn all_the_things_test() {
   let argv = [
     "true", "1.0", "1", "hello", "--quux", "--corge=2.0", "--grault=2",
-    "--garply=world",
+    "--garply=world", "-w", "-f=2.0", "-p=3", "-x=!",
   ]
   let result = the_whole_fruit_basket_cmd(argv)
 
   result
-  |> should.equal(Ok(FruitBasket(True, 1.0, 1, "hello", True, 2.0, 2, "world")))
+  |> should.equal(Ok(FruitBasket(True, 1.0, 1, "hello", False, 4.0, 5, "world!")))
 }
 
 pub fn command_error_test() {

--- a/test/outil_test.gleam
+++ b/test/outil_test.gleam
@@ -109,6 +109,8 @@ fn help_cmd(args: List(String)) -> CommandResult(String, Nil) {
 }
 
 pub fn help_usage_test() {
+  assert Ok("baz") = help_cmd([])
+
   assert Error(Help(usage)) = help_cmd(["--help"])
 
   usage


### PR DESCRIPTION
See #11 

The way `--help` was implemented piggybacks on the positional argument error handling(!) and this meant commands with, say, only options could not use the automatic help feature.

Fix by adding a wrapper that can both first check for --help and then run your command before "catching" command errors and returning the usage text.