### PR TITLE
Describe command line errors in usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ and its documentation can be found at <https://hexdocs.pm/outil>.
 
 ## Changelog
 
+### 0.3.3
+
+* Made `--help` show itself in the output.
+* Made the usage text present the command line error that caused it to be shown.
+
 ### 0.3.2
 
 * Fixed a bug where the automatic `--help` flag didn't react unless the command had positional arguments.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "outil"
-version = "0.3.3-rc.1"
+version = "0.3.3"
 description = "A Gleam library for writing command line tools."
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "fabjan", repo = "outil" }

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "outil"
-version = "0.3.2"
+version = "0.3.3-rc.1"
 description = "A Gleam library for writing command line tools."
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "fabjan", repo = "outil" }

--- a/src/outil/help.gleam
+++ b/src/outil/help.gleam
@@ -31,7 +31,7 @@ pub fn wrap_usage(cmd: Command, continue: UseArgs(a)) -> CommandResult(a, _) {
     let err_desc = case reason {
       error.MissingArgument(opt) -> "Missing argument for option: " <> opt
       error.MalformedArgument(opt, value) ->
-        "Malformed argument for option: " <> opt <> "(" <> value <> ")"
+        "Malformed argument for option: " <> opt <> " (" <> value <> ")"
       error.OutOfPlaceOption(opt) -> "Out of place option: " <> opt
     }
     CommandLineError(reason, usage(cmd, Some(err_desc)))

--- a/test/outil_test.gleam
+++ b/test/outil_test.gleam
@@ -11,14 +11,6 @@ pub fn main() {
   gleeunit.main()
 }
 
-const hello_usage = "hello -- Say hello to someone.
-
-Usage: hello <name>
-
-Options:
-  --enthusiasm  How enthusiastic? (int, default: 1)
-  --loudly  Use all caps. (bool, default: false)"
-
 fn hello_cmd(args: List(String)) -> CommandResult(String, Nil) {
   use cmd <- command("hello", "Say hello to someone.", args)
   use name, cmd <- arg.string(cmd, "name")
@@ -118,41 +110,63 @@ const help_usage = "help -- Test help text.
 Usage: help
 
 Options:
-  --foo  bar (string, default: \"baz\")"
+  --foo  bar (string, default: \"baz\")
+  -h, --help  Show this help text and exit."
 
-fn help_cmd(args: List(String)) -> CommandResult(String, Nil) {
+// verify that the help text works even if there are no positional arguments
+fn help_opt_cmd(args: List(String)) -> CommandResult(String, Nil) {
   use cmd <- command("help", "Test help text.", args)
   use foo, cmd <- opt.string(cmd, "foo", "bar", "baz")
 
   foo(cmd)
 }
 
-pub fn help_usage_test() {
-  assert Ok("baz") = help_cmd([])
+pub fn help_opt_test() {
+  assert Ok("baz") = help_opt_cmd([])
 
-  assert Error(Help(usage)) = help_cmd(["--help"])
+  assert Error(Help(usage)) = help_opt_cmd(["--help"])
 
   usage
   |> should.equal(help_usage)
 }
 
-pub fn command_usage_test() {
+pub fn command_error_usage_test() {
+  let expect_usage =
+    "hello -- ERROR! Missing argument for option: name
+
+Usage: hello <name>
+
+Options:
+  --enthusiasm  How enthusiastic? (int, default: 1)
+  --loudly  Use all caps. (bool, default: false)
+  -h, --help  Show this help text and exit."
+
   let result = hello_cmd([])
 
   assert Error(CommandLineError(_, usage)) = result
 
   usage
-  |> should.equal(hello_usage)
+  |> should.equal(expect_usage)
 }
 
 pub fn help_test() {
+  let expect_usage =
+    "hello -- Say hello to someone.
+
+Usage: hello <name>
+
+Options:
+  --enthusiasm  How enthusiastic? (int, default: 1)
+  --loudly  Use all caps. (bool, default: false)
+  -h, --help  Show this help text and exit."
+
   let argv = ["--help"]
   let result = hello_cmd(argv)
 
   assert Error(Help(usage)) = result
 
   usage
-  |> should.equal(hello_usage)
+  |> should.equal(expect_usage)
 }
 
 pub fn execute_command_test() {


### PR DESCRIPTION
If the usage text is created from a command line error, put the error text in it.

Also make `--help` show itself in it.