### PR TITLE
Use Gleam 0.27, deprecate try

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.2
         with:
           otp-version: "25.2"
-          gleam-version: "0.26.1"
+          gleam-version: "0.27.0"
           rebar3-version: "3"
           # elixir-version: "1.14.2"
       - run: gleam format --check src test

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ fn say_hello(args) {
   use name, cmd <- arg.string(cmd, "name")
   use enthusiasm, cmd <- opt.int(cmd, "enthusiasm", "How enthusiastic?", 1)
 
-  try name = name(cmd)
-  try enthusiasm = enthusiasm(cmd)
+  use name <- name(cmd)
+  use enthusiasm <- enthusiasm(cmd)
 
   let message = "Hello, " <> name <> string.repeat("!", enthusiasm)
 
@@ -64,6 +64,11 @@ gleam add outil
 and its documentation can be found at <https://hexdocs.pm/outil>.
 
 ## Changelog
+
+### 0.4.0
+
+* Adapted to Gleam 0.27, so no more try syntax.
+* BREAKING -- API change to let library users use use without result.then wrapping.
 
 ### 0.3.3
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,11 +1,11 @@
 name = "outil"
-version = "0.3.3"
+version = "0.4.0"
 description = "A Gleam library for writing command line tools."
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "fabjan", repo = "outil" }
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
+  { name = "gleam_stdlib", version = "0.27.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "9DBDD21B48C654182CDD8AA15ACF85E8E74A0438583C68BD7EF08BE89F999C6F" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/src/outil.gleam
+++ b/src/outil.gleam
@@ -90,14 +90,6 @@ pub type CommandReturn(a) {
 pub type CommandResult(a, b) =
   Result(a, CommandReturn(b))
 
-/// The type of functions that execute a command.
-pub type RunCommand(a, b) =
-  fn(Command) -> CommandResult(a, b)
-
-/// The type of continuation functions in building a command.
-pub type Configure(a, b, c) =
-  fn(RunCommand(a, c), Command) -> b
-
 /// Parse a Bool from a string.
 pub fn parse_bool(arg: String) -> Result(Bool, Nil) {
   case arg {

--- a/src/outil/arg.gleam
+++ b/src/outil/arg.gleam
@@ -3,7 +3,7 @@ import gleam/int
 import gleam/list
 import gleam/result
 import outil.{
-  Argument, BoolArgument, Command, Configure, FloatArgument, IntArgument,
+  Argument, BoolArgument, Command, CommandReturn, FloatArgument, IntArgument,
   StringArgument, parse_bool,
 }
 import outil/error.{MalformedArgument,
@@ -11,23 +11,23 @@ import outil/error.{MalformedArgument,
 import outil/help
 
 /// Add a positional bool argument to the command before continuing.
-pub fn bool(cmd: Command, name: String, continue: Configure(Bool, a, _)) -> a {
+pub fn bool(cmd: Command, name: String, continue) {
   with_positional_argument(cmd, BoolArgument(name), parse_bool, continue)
 }
 
 /// Add a positional float argument to the command before continuing.
-pub fn float(cmd: Command, name: String, continue: Configure(Float, a, _)) -> a {
+pub fn float(cmd: Command, name: String, continue) {
   with_positional_argument(cmd, FloatArgument(name), float.parse, continue)
 }
 
 /// Add a positional int argument to the command before continuing.
-pub fn int(cmd: Command, name: String, continue: Configure(Int, a, _)) -> a {
+pub fn int(cmd: Command, name: String, continue) {
   with_positional_argument(cmd, IntArgument(name), int.parse, continue)
 }
 
 /// Add a positional string argument to the command before continuing.
-pub fn string(cmd: Command, name: String, cont: Configure(String, a, _)) -> a {
-  with_positional_argument(cmd, StringArgument(name), Ok, cont)
+pub fn string(cmd: Command, name: String, continue) {
+  with_positional_argument(cmd, StringArgument(name), Ok, continue)
 }
 
 /// Add a positional argument to the command.
@@ -37,12 +37,18 @@ pub fn string(cmd: Command, name: String, cont: Configure(String, a, _)) -> a {
 fn with_positional_argument(
   cmd: Command,
   argument: Argument,
-  parse: fn(String) -> Result(b, Nil),
-  continue: Configure(b, a, _),
-) -> a {
+  parse: fn(String) -> Result(a, Nil),
+  continue,
+) {
   let arg_pos = list.length(cmd.arguments)
   let arg_parser = positional_arg_parser(arg_pos, argument.name, parse)
-  let arg_parser = fn(run_cmd: Command) { help.wrap_usage(run_cmd, arg_parser) }
+  let arg_parser = fn(
+    run_cmd: Command,
+    and_then: fn(a) -> Result(b, CommandReturn(c)),
+  ) {
+    help.wrap_usage(run_cmd, arg_parser)
+    |> result.then(and_then)
+  }
 
   continue(arg_parser, append_argument(cmd, argument))
 }

--- a/src/outil/help.gleam
+++ b/src/outil/help.gleam
@@ -21,10 +21,10 @@ pub type UseArgs(a) =
 pub fn wrap_usage(cmd: Command, continue: UseArgs(a)) -> CommandResult(a, _) {
   let argv_contains = fn(s) { list.contains(cmd.argv, s) }
 
-  try args = case argv_contains("--help") || argv_contains("-h") {
+  use args <- result.then(case argv_contains("--help") || argv_contains("-h") {
     True -> Error(Help(usage(cmd, None)))
     False -> Ok(cmd.argv)
-  }
+  })
 
   continue(args)
   |> result.map_error(fn(reason) {

--- a/test/outil_test.gleam
+++ b/test/outil_test.gleam
@@ -1,3 +1,4 @@
+import gleam/result
 import gleam/option.{Some}
 import gleam/string
 import gleeunit
@@ -17,9 +18,9 @@ fn hello_cmd(args: List(String)) -> CommandResult(String, Nil) {
   use enthusiasm, cmd <- opt.int(cmd, "enthusiasm", "How enthusiastic?", 1)
   use loudly, cmd <- opt.bool(cmd, "loudly", "Use all caps.")
 
-  try name = name(cmd)
-  try enthusiasm = enthusiasm(cmd)
-  try loudly = loudly(cmd)
+  use name <- result.then(name(cmd))
+  use enthusiasm <- result.then(enthusiasm(cmd))
+  use loudly <- result.then(loudly(cmd))
 
   let message = "Hello, " <> name <> string.repeat("!", enthusiasm)
 
@@ -63,20 +64,20 @@ fn the_whole_fruit_basket_cmd(
   use plugh, cmd <- opt.int_(cmd, "plugh", Some("p"), "add to grault", 1)
   use xyzzy, cmd <- opt.string_(cmd, "xyzzy", Some("x"), "garply suffix", "!")
 
-  try foo = foo(cmd)
-  try bar = bar(cmd)
-  try baz = baz(cmd)
-  try qux = qux(cmd)
+  use foo <- result.then(foo(cmd))
+  use bar <- result.then(bar(cmd))
+  use baz <- result.then(baz(cmd))
+  use qux <- result.then(qux(cmd))
 
-  try quux = quux(cmd)
-  try corge = corge(cmd)
-  try grault = grault(cmd)
-  try garply = garply(cmd)
+  use quux <- result.then(quux(cmd))
+  use corge <- result.then(corge(cmd))
+  use grault <- result.then(grault(cmd))
+  use garply <- result.then(garply(cmd))
 
-  try waldo = waldo(cmd)
-  try fred = fred(cmd)
-  try plugh = plugh(cmd)
-  try xyzzy = xyzzy(cmd)
+  use waldo <- result.then(waldo(cmd))
+  use fred <- result.then(fred(cmd))
+  use plugh <- result.then(plugh(cmd))
+  use xyzzy <- result.then(xyzzy(cmd))
 
   Ok(FruitBasket(
     foo,
@@ -95,8 +96,8 @@ fn twoface_cmd(args: List(String)) -> CommandResult(String, String) {
   use heads, cmd <- opt.bool(cmd, "heads", "Heads?")
   use tails, cmd <- opt.bool(cmd, "tails", "Tails?")
 
-  try heads = heads(cmd)
-  try tails = tails(cmd)
+  use heads <- result.then(heads(cmd))
+  use tails <- result.then(tails(cmd))
 
   case #(heads, tails) {
     #(True, False) -> Ok("Heads!")
@@ -122,9 +123,9 @@ fn help_opt_cmd(args: List(String)) -> CommandResult(String, Nil) {
 }
 
 pub fn help_opt_test() {
-  assert Ok("baz") = help_opt_cmd([])
+  let assert Ok("baz") = help_opt_cmd([])
 
-  assert Error(Help(usage)) = help_opt_cmd(["--help"])
+  let assert Error(Help(usage)) = help_opt_cmd(["--help"])
 
   usage
   |> should.equal(help_usage)
@@ -143,7 +144,7 @@ Options:
 
   let result = hello_cmd([])
 
-  assert Error(CommandLineError(_, usage)) = result
+  let assert Error(CommandLineError(_, usage)) = result
 
   usage
   |> should.equal(expect_usage)
@@ -163,7 +164,7 @@ Options:
   let argv = ["--help"]
   let result = hello_cmd(argv)
 
-  assert Error(Help(usage)) = result
+  let assert Error(Help(usage)) = result
 
   usage
   |> should.equal(expect_usage)
@@ -197,7 +198,7 @@ pub fn missing_argument_test() {
   let argv = []
   let result = hello_cmd(argv)
 
-  assert Error(CommandLineError(reason, _)) = result
+  let assert Error(CommandLineError(reason, _)) = result
 
   reason
   |> should.equal(MissingArgument("name"))
@@ -207,7 +208,7 @@ pub fn malformed_argument_test() {
   let argv = ["world", "--enthusiasm=three"]
   let result = hello_cmd(argv)
 
-  assert Error(CommandLineError(reason, _)) = result
+  let assert Error(CommandLineError(reason, _)) = result
 
   reason
   |> should.equal(MalformedArgument("enthusiasm", "three"))

--- a/test/outil_test.gleam
+++ b/test/outil_test.gleam
@@ -1,4 +1,3 @@
-import gleam/result
 import gleam/option.{Some}
 import gleam/string
 import gleeunit
@@ -15,12 +14,12 @@ pub fn main() {
 fn hello_cmd(args: List(String)) -> CommandResult(String, Nil) {
   use cmd <- command("hello", "Say hello to someone.", args)
   use name, cmd <- arg.string(cmd, "name")
+
   use enthusiasm, cmd <- opt.int(cmd, "enthusiasm", "How enthusiastic?", 1)
   use loudly, cmd <- opt.bool(cmd, "loudly", "Use all caps.")
-
-  use name <- result.then(name(cmd))
-  use enthusiasm <- result.then(enthusiasm(cmd))
-  use loudly <- result.then(loudly(cmd))
+  use name <- name(cmd)
+  use enthusiasm <- enthusiasm(cmd)
+  use loudly <- loudly(cmd)
 
   let message = "Hello, " <> name <> string.repeat("!", enthusiasm)
 
@@ -64,20 +63,20 @@ fn the_whole_fruit_basket_cmd(
   use plugh, cmd <- opt.int_(cmd, "plugh", Some("p"), "add to grault", 1)
   use xyzzy, cmd <- opt.string_(cmd, "xyzzy", Some("x"), "garply suffix", "!")
 
-  use foo <- result.then(foo(cmd))
-  use bar <- result.then(bar(cmd))
-  use baz <- result.then(baz(cmd))
-  use qux <- result.then(qux(cmd))
+  use foo <- foo(cmd)
+  use bar <- bar(cmd)
+  use baz <- baz(cmd)
+  use qux <- qux(cmd)
 
-  use quux <- result.then(quux(cmd))
-  use corge <- result.then(corge(cmd))
-  use grault <- result.then(grault(cmd))
-  use garply <- result.then(garply(cmd))
+  use quux <- quux(cmd)
+  use corge <- corge(cmd)
+  use grault <- grault(cmd)
+  use garply <- garply(cmd)
 
-  use waldo <- result.then(waldo(cmd))
-  use fred <- result.then(fred(cmd))
-  use plugh <- result.then(plugh(cmd))
-  use xyzzy <- result.then(xyzzy(cmd))
+  use waldo <- waldo(cmd)
+  use fred <- fred(cmd)
+  use plugh <- plugh(cmd)
+  use xyzzy <- xyzzy(cmd)
 
   Ok(FruitBasket(
     foo,
@@ -96,8 +95,8 @@ fn twoface_cmd(args: List(String)) -> CommandResult(String, String) {
   use heads, cmd <- opt.bool(cmd, "heads", "Heads?")
   use tails, cmd <- opt.bool(cmd, "tails", "Tails?")
 
-  use heads <- result.then(heads(cmd))
-  use tails <- result.then(tails(cmd))
+  use heads <- heads(cmd)
+  use tails <- tails(cmd)
 
   case #(heads, tails) {
     #(True, False) -> Ok("Heads!")
@@ -106,7 +105,7 @@ fn twoface_cmd(args: List(String)) -> CommandResult(String, String) {
   }
 }
 
-const help_usage = "help -- Test help text.
+const expect_help_usage = "help -- Test help text.
 
 Usage: help
 
@@ -119,16 +118,17 @@ fn help_opt_cmd(args: List(String)) -> CommandResult(String, Nil) {
   use cmd <- command("help", "Test help text.", args)
   use foo, cmd <- opt.string(cmd, "foo", "bar", "baz")
 
-  foo(cmd)
+  use x <- foo(cmd)
+
+  Ok(x)
 }
 
 pub fn help_opt_test() {
-  let assert Ok("baz") = help_opt_cmd([])
+  help_opt_cmd([])
+  |> should.equal(Ok("baz"))
 
-  let assert Error(Help(usage)) = help_opt_cmd(["--help"])
-
-  usage
-  |> should.equal(help_usage)
+  help_opt_cmd(["--help"])
+  |> should.equal(Error(Help(expect_help_usage)))
 }
 
 pub fn command_error_usage_test() {

--- a/test/outil_test.gleam
+++ b/test/outil_test.gleam
@@ -105,14 +105,6 @@ fn twoface_cmd(args: List(String)) -> CommandResult(String, String) {
   }
 }
 
-const expect_help_usage = "help -- Test help text.
-
-Usage: help
-
-Options:
-  --foo  bar (string, default: \"baz\")
-  -h, --help  Show this help text and exit."
-
 // verify that the help text works even if there are no positional arguments
 fn help_opt_cmd(args: List(String)) -> CommandResult(String, Nil) {
   use cmd <- command("help", "Test help text.", args)
@@ -124,6 +116,15 @@ fn help_opt_cmd(args: List(String)) -> CommandResult(String, Nil) {
 }
 
 pub fn help_opt_test() {
+  let expect_help_usage =
+    "help -- Test help text.
+
+Usage: help
+
+Options:
+  --foo  bar (string, default: \"baz\")
+  -h, --help  Show this help text and exit."
+
   help_opt_cmd([])
   |> should.equal(Ok("baz"))
 
@@ -142,9 +143,7 @@ Options:
   --loudly  Use all caps. (bool, default: false)
   -h, --help  Show this help text and exit."
 
-  let result = hello_cmd([])
-
-  let assert Error(CommandLineError(_, usage)) = result
+  let assert Error(CommandLineError(_, usage)) = hello_cmd([])
 
   usage
   |> should.equal(expect_usage)
@@ -161,13 +160,8 @@ Options:
   --loudly  Use all caps. (bool, default: false)
   -h, --help  Show this help text and exit."
 
-  let argv = ["--help"]
-  let result = hello_cmd(argv)
-
-  let assert Error(Help(usage)) = result
-
-  usage
-  |> should.equal(expect_usage)
+  hello_cmd(["--help"])
+  |> should.equal(Error(Help(expect_usage)))
 }
 
 pub fn execute_command_test() {
@@ -195,10 +189,7 @@ pub fn int_opt_test() {
 }
 
 pub fn missing_argument_test() {
-  let argv = []
-  let result = hello_cmd(argv)
-
-  let assert Error(CommandLineError(reason, _)) = result
+  let assert Error(CommandLineError(reason, _)) = hello_cmd([])
 
   reason
   |> should.equal(MissingArgument("name"))


### PR DESCRIPTION
Gleam 0.27 is deprecating the `try` syntax in favor of `use`. Time to figure out how to make Outil handle this.

`gleam fix` transform this (usage of Outil):

```gleam
  try foo = foo(cmd)
  try bar = bar(cmd)
  try baz = baz(cmd)
  try qux = qux(cmd)
```

into:

```gleam
  use foo <- result.then(foo(cmd))
  use bar <- result.then(bar(cmd))
  use baz <- result.then(baz(cmd))
  use qux <- result.then(qux(cmd))
```

which is not quite as ergonomic to use.

I need to figure out how to type all the continuations to enable users writing:

```gleam
  use foo <- foo(cmd)
  use bar <- bar(cmd)
  use baz <- baz(cmd)
  use qux <- qux(cmd)
```

but I'm not quite there yet ....