### PR TITLE
use Gleam 0.28 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.2
         with:
           otp-version: "25.2"
-          gleam-version: "0.27.0"
+          gleam-version: "0.28.1"
           rebar3-version: "3"
           # elixir-version: "1.14.2"
       - run: gleam format --check src test


### PR DESCRIPTION
Updating CI means we know it still works with the latest Gleam version.

No need to bump the dependencies for this library I think, however, since no changes were made to the code so there are no new requirements.